### PR TITLE
add relative filename resolution

### DIFF
--- a/gfx.lisp
+++ b/gfx.lisp
@@ -5,9 +5,10 @@
 ;;; shader utilities
 ;;;
 
-(defun load-shader (path)
+(defun load-shader (pathspec)
   "Load a shader given a path. Shader type is guessed from filename."
-  (let* ((ext (subseq path (- (length path) 4)))
+  (let* ((path (resolve-filename pathspec))
+         (ext (subseq path (- (length path) 4)))
          (type (cond ((equal ext "vert") :vertex-shader)
                      ((equal ext "frag") :fragment-shader)
                      ((equal ext "geom") :geometry-shader))))
@@ -59,9 +60,10 @@ variable in the program."
 ;;; texture utilities
 ;;;
 
-(defun image->texture (path &key texture-min-filter texture-mag-filter)
+(defun image->texture (pathspec &key texture-min-filter texture-mag-filter)
   "Read an image file into an OpenGL texture. Returns texture, width, height. "
-  (let* ((image (png-read:read-png-file path))
+  (let* ((path (resolve-filename pathspec))
+         (image (png-read:read-png-file path))
          (data (png-read:image-data image))
          (width (array-dimension data 1))
          (height (array-dimension data 0))

--- a/util.lisp
+++ b/util.lisp
@@ -1,6 +1,20 @@
 (in-package #:lgame)
 
 ;;;
+;;; variables
+;;;
+
+(defvar *source-directory* (asdf:system-source-directory '#:lgame)
+  "Pathname to merge in order to resolve relative pathnames.")
+
+;;;
+;;; functions
+;;;
+
+(defun resolve-filename (pathspec)
+  (namestring (merge-pathnames pathspec *source-directory*)))
+
+;;;
 ;;; macros
 ;;;
 


### PR DESCRIPTION
Introduced variable _source-directory_ which defaults to the source directory of the lgame ASDF system.

At one point when I restarted slime, the default-directory of emacs was my home directory, not the working dir of the lgame repo. It then couldn't load the shaders and textures, so I added the smarts to find their location.
